### PR TITLE
chore: update discord link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -56,7 +56,7 @@
         <li><a href="https://stacktical.com">DSLA Protocol</a></li>
         <li><a href="https://dsla.network">DSLA Network</a></li>
         <li><a href="https://t.me/stacktical">Community Telegram</a></li>
-        <li><a href="https://discord.gg/9tAFnTsj">Developer Discord</a></li>
+        <li><a href="https://discord.gg/2XhwdRjFnn">Developer Discord</a></li>
     </ul>   
 </nav>
 


### PR DESCRIPTION
This PR updates the Discord link in the default layout, replacing the current invalid link.